### PR TITLE
LP-160 Set process exit code

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,7 +108,7 @@ switch (Yargs.argv.action) {
                 if (error instanceof Exception) {
                     console.log(Chalk.red(error.getMessage()));
                 }
-                process.exit(1);
+                process.exitCode = 1;
             }
         })();
         break;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,6 +108,7 @@ switch (Yargs.argv.action) {
                 if (error instanceof Exception) {
                     console.log(Chalk.red(error.getMessage()));
                 }
+                process.exit(1);
             }
         })();
         break;


### PR DESCRIPTION
On failure set the process exit code to 1.
I can chain commands and check the results of this command
before proceeding to the next command.